### PR TITLE
The system cron wants a username

### DIFF
--- a/cmd/acmetool/quickstart.go
+++ b/cmd/acmetool/quickstart.go
@@ -222,8 +222,10 @@ func formulateCron() string {
 	s := ""
 	if runningAsRoot() {
 		s = "SHELL=/bin/sh\nPATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin\nMAILTO=root\n"
-	}
-	s += fmt.Sprintf("%d %d * * * %s --batch ", m, h, exepath.Abs)
+		s += fmt.Sprintf("%d %d * * * root %s --batch ", m, h, exepath.Abs)
+	} else {
+	        s += fmt.Sprintf("%d %d * * * %s --batch ", m, h, exepath.Abs)
+        }
 	if *stateFlag != storage.RecommendedPath {
 		s += fmt.Sprintf(`--state="%s" `, *stateFlag)
 	}


### PR DESCRIPTION
The system crond wants a username as the sixth parameter in a crontab line. This patch adds 'root' if acmetool is running as root. Fixes the following error:

cron[890]: Error: bad username; while reading /etc/cron.d/acmetool
cron[890]: (*system*acmetool) ERROR (Syntax error, this crontab file will be ignored)