### PR TITLE
Update hooks/reload script

### DIFF
--- a/cmd/acmetool/quickstart.go
+++ b/cmd/acmetool/quickstart.go
@@ -85,7 +85,7 @@ SERVICES="httpd apache2 apache nginx tengine lighttpd postfix dovecot exim exim4
 # Restart services.
 if which systemctl >/dev/null 2>/dev/null; then
   for x in $SERVICES; do
-    [ -e "/lib/systemd/system/$x.service" -o -e "/etc/systemd/system/$x.service" ] && systemctl reload "$x.service" >/dev/null 2>/dev/null || true
+    [ -e "/lib/systemd/system/$x.service" -o -e "/etc/systemd/system/$x.service" -o -e "/etc/init.d/$x" ] && systemctl reload "$x.service" >/dev/null 2>/dev/null || true
   done
   exit 0
 fi


### PR DESCRIPTION
Some daemons don't have their own systemd service unit file,
(In my case, it was apache2 on Debian Jessie - not shipped with *apache2.service* file)

so they will not be reloaded with current reload script.

Changing the sequence of code (`which systemctl` and `which service`) also worked,

but I think it is the least redundant way.