### PR TITLE
Explicitly use bash for the reload hook

### DIFF
--- a/cmd/acmetool/quickstart.go
+++ b/cmd/acmetool/quickstart.go
@@ -94,7 +94,7 @@ func cmdQuickstart() {
 	promptGettingStarted()
 }
 
-const reloadHookFile = `#!/bin/sh
+const reloadHookFile = `#!/bin/bash
 ## This file was installed by acmetool. Any updates to this script will
 ## overwrite changes you make. If you don't want acmetool to manage
 ## this file, remove the following line.


### PR DESCRIPTION
Using ``/bin/sh`` is not guaranteed to work across distributions. Specifically failed for me on Ubuntu (Xenial) as the default shell is not bash.