### PR TITLE
HTTP challenge provisioning hooks support

### DIFF
--- a/_doc/SCHEMA.md
+++ b/_doc/SCHEMA.md
@@ -507,7 +507,9 @@ They can be used to install challenge files at arbitrary locations.
 The first argument is the hostname to which the challenge relates.
 
 The second argument is the filename of the target file causing the challenge to
-be completed.
+be completed. This may be the empty string in some circumstances; for example,
+when an authorization is being obtained for the purposes of performing
+revocation rather than for obtaining a certificate.
 
 The third argument is the filename which must be provisioned under
 `/.well-known/acme-challenge/`.

--- a/cmd/acmetool/quickstart.go
+++ b/cmd/acmetool/quickstart.go
@@ -102,7 +102,7 @@ const reloadHookFile = `#!/bin/bash
 
 set -e
 EVENT_NAME="$1"
-[ "$EVENT_NAME" == "live-updated" ] || exit 0
+[ "$EVENT_NAME" == "live-updated" ] || exit 42
 
 SERVICES="httpd apache2 apache nginx tengine lighttpd postfix dovecot exim exim4 haproxy"
 [ -e "/etc/default/acme-reload" ] && . /etc/default/acme-reload
@@ -142,7 +142,7 @@ const haproxyReloadHookFile = `#!/bin/bash
 
 set -e
 EVENT_NAME="$1"
-[ "$EVENT_NAME" == "live-updated" ] || exit 0
+[ "$EVENT_NAME" == "live-updated" ] || exit 42
 
 [ -e "/etc/default/acme-reload" ] && . /etc/default/acme-reload
 [ -e "/etc/conf.d/acme-reload" ] && . /etc/conf.d/acme-reload

--- a/responder/responder.go
+++ b/responder/responder.go
@@ -88,12 +88,17 @@ type ChallengeConfig struct {
 	//
 	// If not specified, proofOfPossession challenges always fail.
 	PriorKeyFunc PriorKeyFunc
+
+	StartHookFunc HookFunc
+	StopHookFunc  HookFunc
 }
 
 // Returns the private key corresponding to the given public key, if it can be
 // found. If a corresponding private key cannot be found, return nil; do not
 // return an error. Returning an error short circuits.
 type PriorKeyFunc func(crypto.PublicKey) (crypto.PrivateKey, error)
+
+type HookFunc func(challengeInfo interface{}) error
 
 var responderTypes = map[string]func(Config) (Responder, error){}
 


### PR DESCRIPTION
Adds support for using hook scripts to provision and deprovision HTTP challenge files. The calling convention is documented in the changes to SCHEMA.md which are part of this PR.

Fixes #71.