### PR TITLE
Add support for DNS challenge hooks.

### DIFF
--- a/_doc/SCHEMA.md
+++ b/_doc/SCHEMA.md
@@ -535,6 +535,39 @@ ACME_STATE_DIR=/var/lib/acme /usr/lib/acme/hooks/foo \
   evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA
 ```
 
+### challenge-dns-start, challenge-dns-stop
+
+These hooks are invoked when a DNS challenge begins and ends. They can be used
+to install the necessary validation DNS records, for example via DNS UPDATE.
+
+The hook MUST return 0 only if it succeeds at provisioning/deprovisioning the
+challenge. When returning 0 in the `challenge-dns-start` case, it MUST return
+only once the record to be provisioned is globally visible at the primary
+authoritative nameserver for the applicable zone. The primary nameserver is the
+nameserver listed in the SOA record. The hook is not required to consider the
+effects of caching resolvers as ACME servers will perform the lookup directly.
+
+The first argument is the hostname to which the challenge relates.
+
+The second argument is the filename of the target file causing the challenge to
+be completed. This may be the empty string in some circumstances; for example,
+when an authorization is being obtained for the purposes of performing
+revocation rather than for obtaining a certificate.
+
+The third argument is the value of the DNS TXT record to be provisioned.
+
+Note that as per the ACME specification, the TXT record must be provisioned at
+`_acme-challenge.HOSTNAME`, where HOSTNAME is the hostname given.
+
+Example call:
+
+```sh
+ACME_STATE_DIR=/var/lib/acme /usr/lib/acme/hooks/foo \
+  challenge-dns-start example.com some-target-file \
+  evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA
+```
+
+
 SRV-ID
 ------
 

--- a/cmd/acmetool/main.go
+++ b/cmd/acmetool/main.go
@@ -261,6 +261,27 @@ func cmdWant() {
 	s, err := storage.NewFDB(*stateFlag)
 	log.Fatale(err, "storage")
 
+	alreadyExists := false
+	s.VisitTargets(func(t *storage.Target) error {
+		nm := map[string]struct{}{}
+		for _, n := range t.Satisfy.Names {
+			nm[n] = struct{}{}
+		}
+
+		for _, w := range *wantArg {
+			if _, ok := nm[w]; !ok {
+				return nil
+			}
+		}
+
+		alreadyExists = true
+		return nil
+	})
+
+	if alreadyExists {
+		return
+	}
+
 	tgt := storage.Target{
 		Satisfy: storage.TargetSatisfy{
 			Names: *wantArg,

--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -68,6 +68,16 @@ func ChallengeHTTPStop(hookDirectory, stateDirectory, hostname, targetFileName, 
 	return err
 }
 
+func ChallengeDNSStart(hookDirectory, stateDirectory, hostname, targetFileName, body string) (installed bool, err error) {
+	return runParts(hookDirectory, stateDirectory, nil,
+		"challenge-dns-start", hostname, targetFileName, body)
+}
+
+func ChallengeDNSStop(hookDirectory, stateDirectory, hostname, targetFileName, body string) (uninstalled bool, err error) {
+	return runParts(hookDirectory, stateDirectory, nil,
+		"challenge-dns-stop", hostname, targetFileName, body)
+}
+
 // Implements functionality similar to the "run-parts" command on many distros.
 // Implementations vary, so it is reimplemented here.
 func runParts(directory, stateDirectory string, stdinData []byte, args ...string) (anySucceeded bool, err error) {

--- a/solver/preference.go
+++ b/solver/preference.go
@@ -85,7 +85,7 @@ var PreferFast = TypePreferencer{
 
 	// Disable DNS challenges for now. They're practically unusable and the Let's
 	// Encrypt live server doesn't support them at this time anyway.
-	//"dns-01":     -100,
+	"dns-01": -10,
 
 	// Avoid unless necessary. In future we might want to determine whether we
 	// have a key and prefer this accordingly.

--- a/storage/storage-fdb.go
+++ b/storage/storage-fdb.go
@@ -579,8 +579,7 @@ func (s *fdbStore) validateTargetInner(desiredKey string, c *fdb.Collection, loa
 		tgt.Request.implicitNames = true
 	}
 
-	// May be nil.
-	tgt.Request.Account = s.AccountByDirectoryURL(tgt.Request.Provider)
+	// tgt.Request.Account is not set; it is for use by other code.
 
 	return tgt, nil
 }

--- a/storage/types.go
+++ b/storage/types.go
@@ -86,7 +86,8 @@ type TargetRequest struct {
 	// probably be added.
 	Provider string `yaml:"provider,omitempty"`
 
-	// D. Account to use, determined via Provider string.
+	// D. Account to use. The storage package does not set this; it is for the
+	// convenience of consuming code. To be determined via Provider string.
 	Account *Account `yaml:"-"`
 
 	// Settings relating to the creation of new keys used to request

--- a/storageops/util.go
+++ b/storageops/util.go
@@ -43,11 +43,13 @@ func targetGt(a *storage.Target, b *storage.Target) bool {
 	return len(a.Satisfy.Names) > len(b.Satisfy.Names)
 }
 
+const renewalMargin = 14 * 24 * time.Hour // close enough to 14 days
+
 func renewTime(notBefore, notAfter time.Time) time.Time {
 	validityPeriod := notAfter.Sub(notBefore)
 	renewSpan := validityPeriod / 3
-	if renewSpan > 30*24*time.Hour { // close enough to 30 days
-		renewSpan = 30 * 24 * time.Hour
+	if renewSpan > renewalMargin {
+		renewSpan = renewalMargin
 	}
 
 	return notAfter.Add(-renewSpan)


### PR DESCRIPTION
DNS challenges can now be completed. The only method of doing so is via
hooks. acmetool has no capability to modify DNS itself, and acmetool
will never support non-automatable challenge methods such as manual
configuration.

The format for a DNS hook is documented in SCHEMA.md. It is imperative
that the installation hook not return until the specified value is
actually visible at ALL authoritative nameservers for a zone. If your
DNS update mechanism does not provide this guarantee, you should add a
loop in which you poll each authoritative nameserver regularly until the
correct response is identified.

Since Let's Encrypt uses a forced maximum TTL of 60 seconds for its DNS
challenge resolver, you may have issues retrying failed challenges if
you retry them in less than a minute. Please allow time for TTL expiry.

Please note that hooks which do not implement the DNS challenge events
should always return exit code 42 for event types they do not handle.
Hooks which fail to do this will lead acmetool to believe that DNS
challenges have successfully been provisioned and attempt a challenge it
cannot possibly succeed at. Future releases might add integrated DNS
self-testing.

DNS challenges are less preferred than HTTP and TLS-SNI challenges, so
DNS challenges will only be attempted where HTTP and TLS-SNI challenges
fail. This to some extent mitigates the issues which may be caused by
failure to adhere to the advice in the above paragraph. And of course,
acmetool will always try and work through the challenges until one
actually succeeds, so the worst case scenario is that acmetool is a bit
chattier in its interactions with the ACME server, or that error
messages are more confusing due to their mentions of DNS challenges.

The following optimizations were also made:
  - Account-specific clients are now reused, which should cut out a few
    redundant HTTP requests to ACME servers.

The following bug fixes were also made:
  - acmetool would crash if run with a state directory with no accounts.
    This does not usually happen because the quickstart wizard sets up
    an account. Fixed to create an account automatically if an account
    cannot be found for a specified provider.

The following changes were made:
  - Renewal margin was reduced to 14 days or 1/3rd of the certificate
    validity period, whichever is lower.

Fixes #82.
Fixes #93.