### PR TITLE
Fix DNS hook example script

### DIFF
--- a/_doc/dns.hook
+++ b/_doc/dns.hook
@@ -54,7 +54,7 @@ get_apex() {
 waitns() {
   local ns="$1"
   for ctr in $(seq 1 "$DNS_SYNC_TIMEOUT"); do
-    [ "$(dig +short "@${ns}" TXT "_acme-challenge.${CH_HOSTNAME}." | grep "$CH_TXT_VALUE" | wc -l)" == "1" ] && return 0
+    [[ "$(dig +short "@${ns}" TXT "_acme-challenge.${CH_HOSTNAME}." | grep -c "$CH_TXT_VALUE")" -eq 1 ]] && return 0
     sleep 1
   done
 

--- a/_doc/dns.hook
+++ b/_doc/dns.hook
@@ -70,7 +70,13 @@ updns() {
   (
     declare -f nsupdate_cmds >/dev/null && nsupdate_cmds
     [ -n "$TKIP_KEY" ] && echo key "$TKIP_KEY_NAME" "$TKIP_KEY"
-    echo $op "_acme-challenge.${CH_HOSTNAME}." 60 IN TXT "\"${CH_TXT_VALUE}\""
+    if [[ $op == "add" ]]; then
+        echo update add "_acme-challenge.${CH_HOSTNAME}." 60 IN TXT "\"${CH_TXT_VALUE}\""
+    elif [[ $op == "del" ]]; then
+        echo update delete "_acme-challenge.${CH_HOSTNAME}." IN TXT
+    else
+        return 1  # not implemented
+    fi
     echo send
   ) | nsupdate $NSUPDATE_ARGS
 }

--- a/_doc/dns.hook
+++ b/_doc/dns.hook
@@ -78,7 +78,7 @@ updns() {
         return 1  # not implemented
     fi
     echo send
-  ) | nsupdate $NSUPDATE_ARGS
+  ) | nsupdate -t 10 $NSUPDATE_ARGS
 }
 
 [ -e "/etc/default/acme-dns" ] && . /etc/default/acme-dns

--- a/_doc/dns.hook
+++ b/_doc/dns.hook
@@ -11,7 +11,7 @@
 #   # not necessary.
 #   TKIP_KEY_NAME="hmac-sha256:tk1"
 #   TKIP_KEY="a base64-encoded TKIP key"
-# 
+#
 #   # DNS synchronization timeout in seconds. Default is 60.
 #   DNS_SYNC_TIMEOUT=60
 #
@@ -32,15 +32,22 @@ set -e
 
 get_apex() {
   local name="$1"
-  if [ -z "$name" ]; then
-    echo "$0: couldn't get apex for $name" >&2
+  if [[ -z "$name" ]]; then
+    echo "$0: couldn't get apex for empty name" >&2
     return 1
   fi
-  if [ "`dig +noall +answer SOA "${name}." |grep SOA|wc -l`" == "1" ]; then
+  # Look up SOA to get APEX and nameserver
+  APEX_NS=$(dig +noall +answer SOA "$name"|awk 'NR==1 && $4 == "SOA" {print $5}')
+  if [[ -n "$APEX_NS" ]]; then
     APEX="$name"
     return
   fi
-  local sname="$(echo $name | sed 's/^[^.]\+\.//')"
+  # If no SOA, check parent domain name (foo.example.com -> example.com)
+  local sname="$(echo $name | sed 's/^[^.]*\.//')"
+  if [[ "$sname" == "$name" ]]; then
+      echo "$0: could not get apex for $CH_HOSTNAME" >&2
+      return 1
+  fi
   get_apex "$sname"
 }
 

--- a/storageops/util.go
+++ b/storageops/util.go
@@ -7,8 +7,9 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
-	"github.com/hlandau/acme/storage"
 	"time"
+
+	"github.com/hlandau/acme/storage"
 )
 
 type targetSorter []*storage.Target
@@ -47,6 +48,7 @@ const renewalMargin = 14 * 24 * time.Hour // close enough to 14 days
 
 func renewTime(notBefore, notAfter time.Time) time.Time {
 	validityPeriod := notAfter.Sub(notBefore)
+	// Renewal is done min(1/3 validity time ; 14 days) before expiry
 	renewSpan := validityPeriod / 3
 	if renewSpan > renewalMargin {
 		renewSpan = renewalMargin
@@ -79,7 +81,8 @@ func generateKey(trk *storage.TargetRequestKey) (pk crypto.PrivateKey, err error
 	return
 }
 
-// Error associated with a specific target, for clarity of error messages.
+// TargetSpecificError is an error associated with a specific target,
+// for clarity of error messages.
 type TargetSpecificError struct {
 	Target *storage.Target
 	Err    error


### PR DESCRIPTION
The DNS hook script was a good example but not quite working. I fixed a few issues that cause it to not work at all on OS X and nsupdate syntax. I have now verified and got certificates from staging API with this script (although I used -k keyfile modified in the arguments instead of /etc/default).

I updated a couple comments in go code, too. Let's encrypt [live server should support dns-01](https://twitter.com/letsencrypt/status/689919523164721152) now, too.