### PR TITLE
http responder: Only bind to default ports if not explicitly configured.

### DIFF
--- a/_doc/SCHEMA.md
+++ b/_doc/SCHEMA.md
@@ -263,7 +263,7 @@ specification and documentation. acmetool supports the following extensions:
         webroot-paths:
           - /some/webroot/path/.well-known/acme-challenge
 
-        # A list of additional ports to listen on. Each item can be a port
+        # A list of ports to listen on. Each item can be a port
         # number, or an explicit bind address (e.g. "[::1]:402"). Specifying a
         # port number x is equivalent to specifying "[::1]:x" and "127.0.0.1:x".
         http-ports:

--- a/responder/http.go
+++ b/responder/http.go
@@ -227,6 +227,10 @@ func (s *httpResponder) getWebroots() map[string]struct{} {
 }
 
 func parseListenAddrs(addrs []string) map[string]struct{} {
+	if addrs == nil {
+		return nil;
+	}
+
 	m := map[string]struct{}{}
 
 	for _, s := range addrs {
@@ -250,14 +254,17 @@ func parseListenAddrs(addrs []string) map[string]struct{} {
 }
 
 func (s *httpResponder) startActual() error {
-	// Here's our brute force method: listen on everything that might work.
 	addrs := parseListenAddrs(s.rcfg.ChallengeConfig.HTTPPorts)
-	addrs["[::1]:80"] = struct{}{}
-	addrs["127.0.0.1:80"] = struct{}{}
-	addrs["[::1]:402"] = struct{}{}
-	addrs["127.0.0.1:402"] = struct{}{}
-	addrs["[::1]:4402"] = struct{}{}
-	addrs["127.0.0.1:4402"] = struct{}{}
+	if addrs == nil {
+		log.Debugf("http-ports not configured, using defaults")
+		addrs = map[string]struct{}{}
+		addrs["[::1]:80"] = struct{}{}
+		addrs["127.0.0.1:80"] = struct{}{}
+		addrs["[::1]:402"] = struct{}{}
+		addrs["127.0.0.1:402"] = struct{}{}
+		addrs["[::1]:4402"] = struct{}{}
+		addrs["127.0.0.1:4402"] = struct{}{}
+	}
 
 	for k := range addrs {
 		s.startListener(k)


### PR DESCRIPTION
Previously, acmetool could not be reliably configured to listen on the
wildcard address on ports 80, 402, or 4402, because the listener might
already have bound to localhost on that port.

The following configuration should now work as expected:

    request:
      challenge:
        http-ports:
          - ":80"
          - ":402"
          - ":4402"