### PR TITLE
Pin to go-jose.v1 instead of using master

### DIFF
--- a/acmeapi/acmeutils/keyauth.go
+++ b/acmeapi/acmeutils/keyauth.go
@@ -11,7 +11,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
-	"github.com/square/go-jose"
+	"gopkg.in/square/go-jose.v1"
 	"math/big"
 	"time"
 )

--- a/acmeapi/api.go
+++ b/acmeapi/api.go
@@ -29,7 +29,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
-	"github.com/square/go-jose"
+	"gopkg.in/square/go-jose.v1"
 
 	denet "github.com/hlandau/degoutils/net"
 	"github.com/peterhellberg/link"

--- a/acmeapi/types.go
+++ b/acmeapi/types.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	denet "github.com/hlandau/degoutils/net"
-	"github.com/square/go-jose"
+	"gopkg.in/square/go-jose.v1"
 	"time"
 )
 

--- a/cmd/acmetool/le-import.go
+++ b/cmd/acmetool/le-import.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hlandau/acme/acmeapi/acmeendpoints"
 	"github.com/hlandau/acme/acmeapi/acmeutils"
 	"github.com/hlandau/acme/storage"
-	"github.com/square/go-jose"
+	"gopkg.in/square/go-jose.v1"
 	"golang.org/x/net/context"
 	"io/ioutil"
 	"os"

--- a/cmd/acmetool/main.go
+++ b/cmd/acmetool/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hlandau/acme/storageops"
 	"github.com/hlandau/degoutils/xlogconfig"
 	"github.com/hlandau/xlog"
-	"github.com/square/go-jose"
+	"gopkg.in/square/go-jose.v1"
 	"gopkg.in/alecthomas/kingpin.v2"
 	"gopkg.in/hlandau/easyconfig.v1/adaptflag"
 	"gopkg.in/hlandau/service.v2"

--- a/responder/possession.go
+++ b/responder/possession.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hlandau/acme/acmeapi"
-	"github.com/square/go-jose"
+	"gopkg.in/square/go-jose.v1"
 )
 
 type proofOfPossessionResponder struct {


### PR DESCRIPTION
Changes the import path for `square/go-jose` to import the package through gopkg. I guarantee backwards-compatibility for the `v1` branch (which is also tagged with releases), whereas `master` may diverge. This gets you on the stable version.