### PR TITLE
Forcefully replace destination in haproxy hook

### DIFF
--- a/cmd/acmetool/quickstart.go
+++ b/cmd/acmetool/quickstart.go
@@ -248,7 +248,7 @@ while read name; do
     cat "$certdir/privkey" "$certdir/fullchain" > "$certdir/haproxy"
   fi
 
-  [ -h "$ACME_STATE_DIR/haproxy/$name" ] || ln -s "../live/$name/haproxy" "$ACME_STATE_DIR/haproxy/$name"
+  [ -h "$ACME_STATE_DIR/haproxy/$name" ] || ln -fs "../live/$name/haproxy" "$ACME_STATE_DIR/haproxy/$name"
 done`
 
 func installHook(name, value string) {


### PR DESCRIPTION
We've encountered a situation where we have to start a webserver daemon
before we can complete the ACME challenge, but the daemon already
requires a key and certificate.

Our solution is to write a regular file with a self-signed certificate
to "$statedir/haproxy/$name" and then rely on the haproxy hook to
replace that file with a symlink to the proper certificate, followed by
the reload hook to actually make use of the newly acquired certificate.

Unfortunately the haproxy hook fails when the destination is already
a regular file:

    acme.hooks: calling hook script […]: /usr/lib/acme/hooks/haproxy
    ln: failed to create symbolic link '[…]/haproxy/example.tld': File exists
    acme.hooks: hook script: /usr/lib/acme/hooks/haproxy: exit status 1

Passing “-f” to “ln” avoids this issue by forcefully removing the
destination if it already exists.

Another solution would be to not check for the existence of any symlink,
but instead of see whether the destination is already a symlink pointing
to the correct target. Then we could install a symlink pointing to the
self-signed certificate, the former of which would be replaced by the
correct symlink. We found that to have a larger impact than this
addition of a single parameter.
