### PR TITLE
Add a config option to try Webroot auth w/o testing first.

### DIFF
--- a/responder/http.go
+++ b/responder/http.go
@@ -90,12 +90,16 @@ func (s *httpResponder) Start() error {
 		return err
 	}
 
-	log.Debug("http-01 self test")
-	err = s.selfTest()
-	if err != nil {
-		log.Infoe(err, "http-01 self test failed")
-		s.Stop()
-		return err
+	if !s.rcfg.ChallengeConfig.ForceWebroot {
+		log.Debug("http-01 self test")
+		err = s.selfTest()
+		if err != nil {
+			log.Infoe(err, "http-01 self test failed")
+			s.Stop()
+			return err
+		}
+	} else {
+		log.Debug("http-01 skipping self test")
 	}
 
 	log.Debug("http-01 started")

--- a/responder/responder.go
+++ b/responder/responder.go
@@ -73,6 +73,11 @@ type ChallengeConfig struct {
 	// Optional.
 	HTTPPorts []string
 
+	// "http-01": Attempt Webroot authentication, even if we can't
+	// access the challenge file via http(s).
+	// Optional.
+	ForceWebroot bool
+
 	// "proofOfPossession": Function which returns the private key for a given
 	// public key.  This may be called multiple times for a given challenge as
 	// multiple public keys may be permitted. If a private key for the given

--- a/storage/types.go
+++ b/storage/types.go
@@ -135,6 +135,10 @@ type TargetRequestChallenge struct {
 
 	// N. Ports to listen on when completing challenges.
 	HTTPPorts []string `yaml:"http-ports,omitempty"`
+
+	// N. Attempt Webroot authentication, even if we can't
+	// access the challenge file via http(s).
+	ForceWebroot bool `yaml:"force-webroot,omitempty"`
 }
 
 // Represents a stored target descriptor.

--- a/storageops/reconcile.go
+++ b/storageops/reconcile.go
@@ -478,6 +478,7 @@ func (r *reconcile) obtainAuthorization(name string, a *storage.Account, targetF
 	ccfg := responder.ChallengeConfig{
 		WebPaths:      trc.WebrootPaths,
 		HTTPPorts:     trc.HTTPPorts,
+		ForceWebroot:  trc.ForceWebroot,
 		PriorKeyFunc:  r.getPriorKey,
 		StartHookFunc: startHookFunc,
 		StopHookFunc:  stopHookFunc,


### PR DESCRIPTION
If a server is not accessible internally, the current code will
always fail. This adds a ForceWebroot flag that disables the
reachability check.