### PR TITLE
Fix DNS challenge if the token starts with a hyphen

### DIFF
--- a/_doc/dns.hook
+++ b/_doc/dns.hook
@@ -47,7 +47,7 @@ get_apex() {
 waitns() {
   local ns="$1"
   for ctr in $(seq 1 "$DNS_SYNC_TIMEOUT"); do
-    [ "$(dig +short "@${ns}" TXT "_acme-challenge.${CH_HOSTNAME}." | grep "$CH_TXT_VALUE" | wc -l)" == "1" ] && return 0
+    [ "$(dig +short "@${ns}" TXT "_acme-challenge.${CH_HOSTNAME}." | grep -- "$CH_TXT_VALUE" | wc -l)" == "1" ] && return 0
     sleep 1
   done
 


### PR DESCRIPTION
There is a small probability that the token stored in `$CH_TXT_VALUE`
starts with a hyphen. In these cases `grep` interprets the token as a
flag, instead of as the pattern, and fails.

This commit uses `--` to force `grep` to interpret `$CH_TXT_VALUE` as the
pattern, even if it starts with a hyphen.