### PR TITLE
Update TOS URL in sample response file

### DIFF
--- a/_doc/response-file.yaml
+++ b/_doc/response-file.yaml
@@ -7,7 +7,7 @@
 # For dialogs not requiring a response, but merely acknowledgement, specify true.
 # This file is YAML. Note that JSON is a subset of YAML.
 "acme-enter-email": "hostmaster@example.com"
-"acme-agreement:https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf": true
+"acme-agreement:https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf": true
 "acmetool-quickstart-choose-server": https://acme-staging.api.letsencrypt.org/directory
 "acmetool-quickstart-choose-method": redirector
 # This is only used if "acmetool-quickstart-choose-method" is "webroot".


### PR DESCRIPTION
`acmetool quickstart --batch` fails with the following error when using the
TOS URL provided in `response-file.yml`:

```
[CRITICAL] acmetool: fatal: couldn't complete registration: cannot prompt the user: currently non-interactive
```

This is rather cryptic and can be avoided by providing the latest TOS URL.