### PR TITLE
Enable copr builds for Fedora 25

### DIFF
--- a/.travis/after_success
+++ b/.travis/after_success
@@ -90,7 +90,7 @@ for srpm in $HOME/rpmbuild/SRPMS/acmetool-*.rpm; do
     cat <<END > /tmp/rpm-metadata
 {
   "project_id": $COPR_PROJECT_ID,
-  "chroots": ["fedora-23-i386", "fedora-23-x86_64", "epel-7-x86_64", "fedora-24-i386", "fedora-24-x86_64"]
+  "chroots": ["fedora-23-i386", "fedora-23-x86_64", "epel-7-x86_64", "fedora-24-i386", "fedora-24-x86_64", "fedora-25-i386", "fedora-25-"x86_64"]
 }
 END
   else

--- a/.travis/boulder.patch
+++ b/.travis/boulder.patch
@@ -23,13 +23,6 @@ index c237d7f..1336bb5 100644
        "httpsPort": 5001,
        "tlsPort": 5001
      },
-@@ -56,4 +56,4 @@
-     "dnsTimeout": "10s",
-     "dnsAllowLoopbackAddresses": true
-   }
--}
-\ No newline at end of file
-+}
 diff --git a/test/config/ca.json b/test/config/ca.json
 index a4d71c8..9057f6f 100644
 --- a/test/config/ca.json
@@ -60,13 +53,6 @@ index 75ff959..371edf3 100644
        "httpsPort": 5001,
        "tlsPort": 5001
      },
-@@ -37,4 +37,4 @@
-     "dnsTimeout": "10s",
-     "dnsAllowLoopbackAddresses": true
-   }
--}
-\ No newline at end of file
-+}
 diff --git a/test/hostname-policy.json b/test/hostname-policy.json
 index 6397ee9..15ad50c 100644
 --- a/test/hostname-policy.json


### PR DESCRIPTION
Routine enabling of builds for the next version of Fedora due in a couple of weeks.
