### PR TITLE
ignore dot files in permission checker

### DIFF
--- a/.travis/boulder.patch
+++ b/.travis/boulder.patch
@@ -23,23 +23,6 @@ index 374ff68..4e701da 100644
        "httpsPort": 5001,
        "tlsPort": 5001
      },
-diff --git a/test/config/ca.json b/test/config/ca.json
-index f0155fe..ddc1ffe 100644
---- a/test/config/ca.json
-+++ b/test/config/ca.json
-@@ -5,10 +5,10 @@
-     "ecdsaProfile": "ecdsaEE",
-     "debugAddr": "localhost:8001",
-     "Issuers": [{
--      "ConfigFile": "test/test-ca.key-pkcs11.json",
-+      "File": "test/test-ca.key",
-       "CertFile": "test/test-ca2.pem"
-     }, {
--      "ConfigFile": "test/test-ca.key-pkcs11.json",
-+      "File": "test/test-ca.key",
-       "CertFile": "test/test-ca.pem"
-     }],
-     "expiry": "2160h",
 diff --git a/test/config/ra.json b/test/config/ra.json
 index a5cbe39..95e03b3 100644
 --- a/test/config/ra.json

--- a/.travis/boulder.patch
+++ b/.travis/boulder.patch
@@ -23,6 +23,23 @@ index 374ff68..4e701da 100644
        "httpsPort": 5001,
        "tlsPort": 5001
      },
+diff --git a/test/config/ca.json b/test/config/ca.json
+index f0155fe..ddc1ffe 100644
+--- a/test/config/ca.json
++++ b/test/config/ca.json
+@@ -5,10 +5,10 @@
+     "ecdsaProfile": "ecdsaEE",
+     "debugAddr": "localhost:8001",
+     "Issuers": [{
+-      "ConfigFile": "test/test-ca.key-pkcs11.json",
++      "File": "test/test-ca.key",
+       "CertFile": "test/test-ca2.pem"
+     }, {
+-      "ConfigFile": "test/test-ca.key-pkcs11.json",
++      "File": "test/test-ca.key",
+       "CertFile": "test/test-ca.pem"
+     }],
+     "expiry": "2160h",
 diff --git a/test/config/ra.json b/test/config/ra.json
 index a5cbe39..95e03b3 100644
 --- a/test/config/ra.json

--- a/.travis/boulder.patch
+++ b/.travis/boulder.patch
@@ -29,15 +29,17 @@ index f0155fe..ddc1ffe 100644
 +++ b/test/config/ca.json
 @@ -5,10 +5,10 @@
      "ecdsaProfile": "ecdsaEE",
-     "debugAddr": "localhost:8001",
+     "debugAddr": ":8001",
      "Issuers": [{
 -      "ConfigFile": "test/test-ca.key-pkcs11.json",
 +      "File": "test/test-ca.key",
-       "CertFile": "test/test-ca2.pem"
+       "CertFile": "test/test-ca2.pem",
+       "NumSessions": 2
      }, {
 -      "ConfigFile": "test/test-ca.key-pkcs11.json",
 +      "File": "test/test-ca.key",
-       "CertFile": "test/test-ca.pem"
+       "CertFile": "test/test-ca.pem",
+       "NumSessions": 2
      }],
      "expiry": "2160h",
 diff --git a/test/config/ra.json b/test/config/ra.json

--- a/fdb/fdb.go
+++ b/fdb/fdb.go
@@ -235,6 +235,9 @@ func (db *DB) conformPermissions() error {
 		if err != nil {
 			return err
 		}
+		if (rpath[0] == '.' && len(rpath) > 1) {
+			return nil
+		}
 
 		mode := info.Mode()
 		switch mode & os.ModeType {


### PR DESCRIPTION
An answer to issue #153

Permission checker will ignore `.*` in /var/lib/acme directory