### PR TITLE
Redirector: allow specifying the status code to use

### DIFF
--- a/cmd/acmetool/main.go
+++ b/cmd/acmetool/main.go
@@ -70,6 +70,7 @@ var (
 	redirectorGIDFlag      = redirectorCmd.Flag("challenge-gid", "GID to chgrp the challenge path to (optional)").String()
 	redirectorReadTimeout  = redirectorCmd.Flag("read-timeout", "Maximum duration before timing out read of the request (default: '10s')").Default("10s").Duration()
 	redirectorWriteTimeout = redirectorCmd.Flag("write-timeout", "Maximum duration before timing out write of the request (default: '20s')").Default("20s").Duration()
+	redirectorStatusCode   = redirectorCmd.Flag("status-code", "HTTP status code to use when redirecting (default: '308')").String()
 
 	testNotifyCmd = kingpin.Command("test-notify", "Test-execute notification hooks as though given hostnames were updated")
 	testNotifyArg = testNotifyCmd.Arg("hostname", "hostnames which have been updated").Strings()
@@ -385,6 +386,7 @@ func cmdRunRedirector() {
 				ChallengeGID:  *redirectorGIDFlag,
 				ReadTimeout:   *redirectorReadTimeout,
 				WriteTimeout:  *redirectorWriteTimeout,
+				StatusCode:    "308",
 			})
 		},
 	})

--- a/redirector/redirector.go
+++ b/redirector/redirector.go
@@ -28,7 +28,7 @@ type Config struct {
 	ChallengeGID  string        `default:"" usage:"GID to chgrp the challenge path to (optional)"`
 	ReadTimeout   time.Duration `default:"" usage:"Maximum duration before timing out read of the request"`
 	WriteTimeout  time.Duration `default:"" usage:"Maximum duration before timing out write of the response"`
-	StatusCode    int           `default:"308" usage:"HTTP redirect status code"`
+	StatusCode    string        `default:"308" usage:"HTTP redirect status code"`
 }
 
 // Simple HTTP to HTTPS redirector.
@@ -36,6 +36,7 @@ type Redirector struct {
 	cfg          Config
 	httpServer   graceful.Server
 	httpListener net.Listener
+	statusCode   int
 	stopping     uint32
 }
 

--- a/redirector/redirector.go
+++ b/redirector/redirector.go
@@ -42,6 +42,7 @@ type Redirector struct {
 
 // Instantiate an HTTP to HTTPS redirector.
 func New(cfg Config) (*Redirector, error) {
+	sc, _ = strconv.Atoi(cfg.StatusCode)
 	r := &Redirector{
 		cfg: cfg,
 		httpServer: graceful.Server{
@@ -53,7 +54,7 @@ func New(cfg Config) (*Redirector, error) {
 				WriteTimeout: cfg.WriteTimeout,
 			},
 		},
-		statusCode: strconv.Atoi(cfg.StatusCode),
+		statusCode: sc,
 	}
 
 	// Try and make the challenge path if it doesn't exist.

--- a/redirector/redirector.go
+++ b/redirector/redirector.go
@@ -53,7 +53,7 @@ func New(cfg Config) (*Redirector, error) {
 				WriteTimeout: cfg.WriteTimeout,
 			},
 		},
-		statusCode: strconv.Atoi(r.cfg.StatusCode),
+		statusCode: strconv.Atoi(cfg.StatusCode),
 	}
 
 	// Try and make the challenge path if it doesn't exist.

--- a/redirector/redirector.go
+++ b/redirector/redirector.go
@@ -42,7 +42,7 @@ type Redirector struct {
 
 // Instantiate an HTTP to HTTPS redirector.
 func New(cfg Config) (*Redirector, error) {
-	sc, _ = strconv.Atoi(cfg.StatusCode)
+	sc, _ := strconv.Atoi(cfg.StatusCode)
 	r := &Redirector{
 		cfg: cfg,
 		httpServer: graceful.Server{

--- a/redirector/redirector.go
+++ b/redirector/redirector.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"sync/atomic"
 	"time"
+	"strconv"
 )
 
 var log, Log = xlog.New("acme.redirector")
@@ -27,6 +28,7 @@ type Config struct {
 	ChallengeGID  string        `default:"" usage:"GID to chgrp the challenge path to (optional)"`
 	ReadTimeout   time.Duration `default:"" usage:"Maximum duration before timing out read of the request"`
 	WriteTimeout  time.Duration `default:"" usage:"Maximum duration before timing out write of the response"`
+	StatusCode    int           `default:"308" usage:"HTTP redirect status code"`
 }
 
 // Simple HTTP to HTTPS redirector.
@@ -50,6 +52,7 @@ func New(cfg Config) (*Redirector, error) {
 				WriteTimeout: cfg.WriteTimeout,
 			},
 		},
+		statusCode: strconv.Atoi(r.cfg.StatusCode),
 	}
 
 	// Try and make the challenge path if it doesn't exist.
@@ -198,10 +201,11 @@ func (r *Redirector) handleRedirect(rw http.ResponseWriter, req *http.Request) {
 		rw.Header().Set("Content-Type", "text/html; charset=utf-8")
 	}
 
-	// This is a permanent redirect and the request method should be preserved.
-	// It's unfortunate if the client has transmitted information in cleartext
-	// via POST, etc., but there's nothing we can do about it at this stage.
-	rw.WriteHeader(308)
+	// This is a permanent redirect and the request method is preserved (308) by
+	// default. It's unfortunate if the client has transmitted information in
+	// cleartext via POST, etc., but there's nothing we can do about it at this
+	// stage.
+	rw.WriteHeader(r.statusCode)
 
 	if req.Method == "GET" {
 		// Redirects issued in response to GET SHOULD have a body pointing to the


### PR DESCRIPTION
This would be incredibly useful as we're having issues with 308s on older browsers.

I'm not very experienced with Go, so am expecting complaints.

#209