### PR TITLE
reload hook: Actually reload init.d scripts

### DIFF
--- a/cmd/acmetool/quickstart.go
+++ b/cmd/acmetool/quickstart.go
@@ -138,7 +138,7 @@ fi
 
 if [ -e "/etc/init.d" ]; then
   for x in $SERVICES; do
-    /etc/init.d/$x >/dev/null 2>/dev/null || true
+    /etc/init.d/$x reload >/dev/null 2>/dev/null || true
   done
   exit 0
 fi`


### PR DESCRIPTION
Previously only e.g. `/etc/init.d/haproxy` was run and success was assumed. This usually only prints help output for the script?

This commit adds the reload parameter to the command so that it'll do something on Centos 6 at least.