### PR TITLE
Update eg response-file acme-agreement URL.

### DIFF
--- a/_doc/response-file.yaml
+++ b/_doc/response-file.yaml
@@ -7,7 +7,7 @@
 # For dialogs not requiring a response, but merely acknowledgement, specify true.
 # This file is YAML. Note that JSON is a subset of YAML.
 "acme-enter-email": "hostmaster@example.com"
-"acme-agreement:https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf": true
+"acme-agreement:https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf": true
 "acmetool-quickstart-choose-server": https://acme-staging.api.letsencrypt.org/directory
 "acmetool-quickstart-choose-method": redirector
 # This is only used if "acmetool-quickstart-choose-method" is "webroot".


### PR DESCRIPTION
The Let's Encrypt ACME subscriber agreement URL [was updated on November 15th](https://community.letsencrypt.org/t/subscriber-agreement-update-november-15-2017/45607). This PR adjusts the example non-interactive `response-file.yaml` from the acmetool `_doc/` directory to use the current URL.