### PR TITLE
Fix undefined status code in redirector test

### DIFF
--- a/redirector/redirector_test.go
+++ b/redirector/redirector_test.go
@@ -20,6 +20,7 @@ func TestRedirector(t *testing.T) {
 	r, err := New(Config{
 		Bind:          ":9847",
 		ChallengePath: dir,
+		StatusCode:    308,
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
net/http panics on invalid WriteHeader status code since commit
golang/go@18ae4c834bdb33903dbf6774f57536c73de923bb.