### PR TITLE
Fix broken URLs and paths

### DIFF
--- a/.travis/dist-readme.md
+++ b/.travis/dist-readme.md
@@ -1,6 +1,6 @@
 # ACME Client Utilities
 
-More information: <https://github.com/hlandau/acme>
+More information: <https://github.com/hlandau/acmetool>
 
 ## Installation and Usage
 
@@ -19,10 +19,10 @@ installation instructions:
   $ ls /var/lib/acme/live/example.com/
 
 For more information on using acmetool, please see the full README at
-  https://github.com/hlandau/acme
+  https://github.com/hlandau/acmetool
 
 ## Licence
 
     © 2015 Hugo Landau <hlandau@devever.net>    MIT License
 
-File issues at <https://github.com/hlandau/acme/issues>.
+File issues at <https://github.com/hlandau/acmetool/issues>.

--- a/.travis/make_debian_env
+++ b/.travis/make_debian_env
@@ -29,7 +29,7 @@ ARCHS="386_cgo amd64_cgo 386 amd64 arm arm64 ppc64 ppc64le"
 
 mkdir -p "$ARCHIVEDIR"
 for ARCH in $ARCHS; do
-  wget -nc -O "$ARCHIVEDIR/acmetool-v$VERSION-linux_$ARCH.tar.gz" "https://github.com/hlandau/acme/releases/download/v$VERSION/acmetool-v$VERSION-linux_$ARCH.tar.gz"
+  wget -nc -O "$ARCHIVEDIR/acmetool-v$VERSION-linux_$ARCH.tar.gz" "https://github.com/hlandau/acmetool/releases/download/v$VERSION/acmetool-v$VERSION-linux_$ARCH.tar.gz"
 done
 
 mkdir -p "$OUTDIR/acmetool_$VERSION"
@@ -58,7 +58,7 @@ cat <<END > "$DEBIANDIR/changelog"
 acmetool ($VERSION-$REVISION) $DISTRO; urgency=medium
 
   * Changelog information not maintained in Debian packaging.
-    See <https://github.com/hlandau/acme/releases>
+    See <https://github.com/hlandau/acmetool/releases>
 
  -- Hugo Landau <hlandau@devever.net>  $DATE_R
 END
@@ -99,7 +99,7 @@ cat <<'END' > "$DEBIANDIR/copyright"
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: acmetool
 Upstream-Contact: Hugo Landau <hlandau@devever.net>
-Source: https://github.com/hlandau/acme
+Source: https://github.com/hlandau/acmetool
 
 Files: *
 Copyright: 2015, Hugo Landau <hlandau@devever.net>

--- a/.travis/make_rpm_spec
+++ b/.travis/make_rpm_spec
@@ -23,7 +23,7 @@ Version: $VERSION
 Release: 1%{?dist}
 Summary: Automatic certificate acquisition tool
 License: MIT
-URL: https://github.com/hlandau/acme
+URL: https://github.com/hlandau/acmetool
 Group: Applications/System
 Requires: libcap
 Conflicts: %{aname}$NOTNOCGO_SUFFIX

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 href="https://webchat.freenode.net/?channels=%23acmetool"><img
 src="https://img.shields.io/badge/webchat-freenode%20%23acmetool-blue.svg"
 alt="[webchat: freenode #acmetool]" /></a> <br/> <a
-href="https://github.com/hlandau/acme/releases"><img
-src="https://img.shields.io/github/downloads/hlandau/acme/total.svg"
+href="https://github.com/hlandau/acmetool/releases"><img
+src="https://img.shields.io/github/downloads/hlandau/acmetool/total.svg"
 alt="[download count]" /></a> <a
-href="https://github.com/hlandau/acme/releases"><img
-src="https://img.shields.io/github/release/hlandau/acme.svg" alt="[version]"
+href="https://github.com/hlandau/acmetool/releases"><img
+src="https://img.shields.io/github/release/hlandau/acmetool.svg" alt="[version]"
 /></a><br/> <a
 href="https://launchpad.net/~hlandau/+archive/ubuntu/rhea/+packages"><img
 src="https://img.shields.io/badge/ppa-debian%2Fubuntu-lightgrey.svg" alt="[ppa
@@ -45,7 +45,7 @@ acmetool to reload your webserver automatically when it renews a certificate.
 
 acmetool is intended to be "magic-free". All of acmetool's state is stored in a
 simple, comprehensible directory of flat files. [The schema for this directory
-is documented.](https://github.com/hlandau/acme/blob/master/_doc/SCHEMA.md)
+is documented.](https://github.com/hlandau/acmetool/blob/master/_doc/SCHEMA.md)
 
 acmetool is intended to work like "make". The state directory expresses target
 domain names, and whenever acmetool is invoked, it ensures that valid
@@ -65,7 +65,7 @@ other servers or for other purposes.
 
 ## Getting Started
 
-**Binary releases:** [Binary releases are available.](https://github.com/hlandau/acme/releases)
+**Binary releases:** [Binary releases are available.](https://github.com/hlandau/acmetool/releases)
 
 Download the release appropriate for your platform and simply copy the
 `acmetool` binary to `/usr/bin`.
@@ -139,8 +139,8 @@ If you are on Linux, you will need to make sure the development files for
 # which hasn't yet been accounted for in some places.
 $ git config --global http.followRedirects true
 
-$ git clone https://github.com/hlandau/acme
-$ cd acme
+$ git clone https://github.com/hlandau/acmetool
+$ cd acmetool
 $ make && sudo make install
 
   # (People familiar with Go with a GOPATH setup can alternatively use go get/go install:)
@@ -239,7 +239,7 @@ running `acmetool` (possibly with `--xlog.severity=debug` for verbose logging).
 
 ## Library
 
-The [client library which these utilities use](https://github.com/hlandau/acme/tree/master/acmeapi) can be used independently by any Go code. [README and source code.](https://github.com/hlandau/acme/tree/master/acmeapi) [Godoc.](https://godoc.org/github.com/hlandau/acme/acmeapi)
+The [client library which these utilities use](https://github.com/hlandau/acmeapi) can be used independently by any Go code. [README and source code.](https://github.com/hlandau/acmeapi) [Godoc.](https://godoc.org/github.com/hlandau/acmeapi)
 
 ## Comparison with...
 

--- a/_doc/FAQ.md
+++ b/_doc/FAQ.md
@@ -1,1 +1,1 @@
-# [This document has moved.](https://hlandau.github.com/acme/userguide#faq)
+# [This document has moved.](https://hlandau.github.com/acmetool/userguide#faq)

--- a/_doc/NOROOT.md
+++ b/_doc/NOROOT.md
@@ -1,1 +1,1 @@
-# [This document has moved.](https://hlandau.github.io/acme/userguide#root-configured-non-root-operation)
+# [This document has moved.](https://hlandau.github.io/acmetool/userguide#root-configured-non-root-operation)

--- a/_doc/PROGRAMMATIC-DOWNLOADING.md
+++ b/_doc/PROGRAMMATIC-DOWNLOADING.md
@@ -3,13 +3,13 @@
 ## With curl
 
 ```sh
-VER="$(curl -s -H 'Accept: application/vnd.github.v3+json' 'https://api.github.com/repos/hlandau/acme/releases/latest' | python -c 'import sys,json;k=json.load(sys.stdin);print(k["tag_name"])')"
-curl -Ls -o acmetool-bin.tar.gz "https://github.com/hlandau/acme/releases/download/$VER/acmetool-$VER-linux_amd64_cgo.tar.gz"
+VER="$(curl -s -H 'Accept: application/vnd.github.v3+json' 'https://api.github.com/repos/hlandau/acmetool/releases/latest' | python -c 'import sys,json;k=json.load(sys.stdin);print(k["tag_name"])')"
+curl -Ls -o acmetool-bin.tar.gz "https://github.com/hlandau/acmetool/releases/download/$VER/acmetool-$VER-linux_amd64_cgo.tar.gz"
 ```
 
 ## With wget
 
 ```sh
-VER="$(wget --quiet -O - --header='Accept: application/vnd.github.v3+json' 'https://api.github.com/repos/hlandau/acme/releases/latest' | python -c 'import sys,json;k=json.load(sys.stdin);print(k["tag_name"])')"
-wget --quiet -O acmetool-bin.tar.gz "https://github.com/hlandau/acme/releases/download/$VER/acmetool-$VER-linux_amd64_cgo.tar.gz"
+VER="$(wget --quiet -O - --header='Accept: application/vnd.github.v3+json' 'https://api.github.com/repos/hlandau/acmetool/releases/latest' | python -c 'import sys,json;k=json.load(sys.stdin);print(k["tag_name"])')"
+wget --quiet -O acmetool-bin.tar.gz "https://github.com/hlandau/acmetool/releases/download/$VER/acmetool-$VER-linux_amd64_cgo.tar.gz"
 ```

--- a/_doc/WSCONFIG.md
+++ b/_doc/WSCONFIG.md
@@ -1,1 +1,1 @@
-# [This document has moved.](https://hlandau.github.io/acme/userguide#web-server-configuration)
+# [This document has moved.](https://hlandau.github.io/acmetool/userguide#web-server-configuration)

--- a/_doc/contrib/APKBUILD
+++ b/_doc/contrib/APKBUILD
@@ -9,7 +9,7 @@
 #
 if [ "$(find version -mmin -30 2>/dev/null | wc -l)" == "0" ]; then
   curl -s -H 'Accept: application/vnd.github.v3+json' \
-  'https://api.github.com/repos/hlandau/acme/releases/latest' | \
+  'https://api.github.com/repos/hlandau/acmetool/releases/latest' | \
   sed 's/^.*"tag_name": *"v\([^"]*\)".*$/\1/;tx;d;:x' > version.tmp || exit 1
   mv version.tmp version
 fi
@@ -18,7 +18,7 @@ pkgname=acmetool
 pkgver="$(cat version)"
 pkgrel=0
 pkgdesc="ACME/Let's Encrypt client"
-url="https://github.com/hlandau/acme"
+url="https://github.com/hlandau/acmetool"
 arch="all"
 license="MIT"
 depends="libcap"
@@ -30,21 +30,21 @@ source=""
 
 prepare() {
   cd "$srcdir"
-  git clone -b "v$pkgver" https://github.com/hlandau/acme || return 1
+  git clone -b "v$pkgver" https://github.com/hlandau/acmetool || return 1
 }
 
 build() {
-  cd "$srcdir/acme" || return 1
+  cd "$srcdir/acmetool" || return 1
   make USE_BUILDINFO=1 || return 1
 
   # For some reason this is necessary in order for the buildinfo to get
   # included properly.
-  rm "$srcdir/acme/bin/$pkgname" || return 1
+  rm "$srcdir/acmetool/bin/$pkgname" || return 1
   make USE_BUILDINFO=1 || return 1
 }
 
 package() {
-  install -Dm0755 "$srcdir/acme/bin/$pkgname" "$pkgdir"/usr/bin/$pkgname || return 1
+  install -Dm0755 "$srcdir/acmetool/bin/$pkgname" "$pkgdir"/usr/bin/$pkgname || return 1
 	mkdir -p "$pkgdir"/usr/share/man/man8
 	"$pkgdir"/usr/bin/$pkgname --help-man | gzip > \
 		"$pkgdir"/usr/share/man/man8/acmetool.man.gz || return 1

--- a/_doc/guide/index.adoc
+++ b/_doc/guide/index.adoc
@@ -28,7 +28,7 @@ state and be transparent in the state that it does use. All state,
 including certificates, is stored in a single directory, by default
 `/var/lib/acme`. The schema for this directory is simple, comprehensible
 and
-https://github.com/hlandau/acme/blob/master/_doc/SCHEMA.md[documented.]
+https://github.com/hlandau/acmetool/blob/master/_doc/SCHEMA.md[documented.]
 
 *Stable filenames.* The certificate for a given hostname `example.com`
 always lives at `/var/lib/acme/live/example.com/{cert,chain,privkey}`.
@@ -80,7 +80,7 @@ You can install acmetool by building from source or by using a binary
 release. Both are easy.
 
 *Installing: using binary releases.*
-https://github.com/hlandau/acme/releases[Binary releases are found
+https://github.com/hlandau/acmetool/releases[Binary releases are found
 here.] Unpack, copy the binary to `/usr/local/bin/acmetool` (or wherever
 you like), and you’re done.
 
@@ -156,7 +156,7 @@ $ sudo pacman -U ./acmetool*.pkg.tar.xz
 ----
 
 *Installing: Alpine Linux users.*
-https://github.com/hlandau/acme/blob/master/_doc/APKBUILD[An APKBUILD
+https://github.com/hlandau/acmetool/blob/master/_doc/contrib/APKBUILD[An APKBUILD
 for building from source is available.]
 
 *Installing: from source.* Clone, make, make install. You will need Go
@@ -172,8 +172,8 @@ called `libcap-dev` or `libcap-devel` or similar.
 # which hasn't yet been accounted for in some places.
 $ git config --global http.followRedirects true
 
-$ git clone https://github.com/hlandau/acme
-$ cd acme
+$ git clone https://github.com/hlandau/acmetool
+$ cd acmetool
 $ make && sudo make install
 ----
 
@@ -273,7 +273,7 @@ executes any executable files in `/usr/lib/acme/hooks` (or
 `/usr/libexec/acme/hooks` if on a distro that uses libexec). You can
 drop your own executable files here, and acmetool will invoke them when
 it changes certificates. (For information on the calling convention, see
-https://github.com/hlandau/acme/blob/master/_doc/SCHEMA.md#notification-hooks[SCHEMA.md].)
+https://github.com/hlandau/acmetool/blob/master/_doc/SCHEMA.md#notification-hooks[SCHEMA.md].)
 
 `acmetool quickstart` installs some default hooks applicable to common
 webservers. These hooks contain the string `#!acmetool-managed!#`.
@@ -353,7 +353,7 @@ $ sudo acmetool
 Target files live in the `desired` directory. An empty target file
 defaults to its filename as the target hostname.
 
-https://github.com/hlandau/acme/blob/master/_doc/SCHEMA.md[More
+https://github.com/hlandau/acmetool/blob/master/_doc/SCHEMA.md[More
 information on the format of the acmetool state directory and target
 files.]
 
@@ -521,7 +521,7 @@ retrievable only from the internet but not the local machine.)
 [[the-state-storage-schema]]
 == The state storage schema
 
-https://github.com/hlandau/acme/blob/master/_doc/SCHEMA.md[The format of
+https://github.com/hlandau/acmetool/blob/master/_doc/SCHEMA.md[The format of
 acmetool’s state directory is authoritatively documented here.] What
 follows is a summary of the more important parts.
 
@@ -611,7 +611,7 @@ acmetool can ask.
 
 To do this, you provide the `--response-file` flag, with the path to a
 YAML file containing response information.
-https://github.com/hlandau/acme/blob/master/_doc/response-file.yaml[An
+https://github.com/hlandau/acmetool/blob/master/_doc/contrib/response-file.yaml[An
 example of such a file is here.]
 
 If you don’t provide a `--response-file` flag, acmetool will try to look
@@ -670,11 +670,11 @@ Challenge hooks are executed when challenge files need to be added or
 removed. Your hook must be synchronous; it must exit only when the
 challenge file is definitely in place and is globally accessible.
 
-https://github.com/hlandau/acme/blob/master/_doc/SCHEMA.md#hooks[See the
+https://github.com/hlandau/acmetool/blob/master/_doc/SCHEMA.md#hooks[See the
 specification for more information.]
 
 Challenge hooks are supported for HTTP, TLS-SNI and DNS challenges.
-https://hlandau.github.io/acme/userguide#annex-external-resources-and-third-party-extentions[A
+https://hlandau.github.io/acmetool/userguide#annex-external-resources-and-third-party-extentions[A
 list of third party challenge hook scripts can be found here.]
 
 [[command-line-options]]
@@ -704,7 +704,7 @@ tried in addition to any webroot you specify, as will proxy and listener
 mode ports.
 
 Fore more information, see
-https://hlandau.github.io/acme/userguide#challenge-completion-philosophy[challenge
+https://hlandau.github.io/acmetool/userguide#challenge-completion-philosophy[challenge
 completion philosophy].
 
 [[annex-root-configured-non-root-operation]]
@@ -824,7 +824,7 @@ other than development anyway.
 
 The list of various tutorials, hook scripts and other integrations
 people have made for acmetool is now maintained
-https://github.com/hlandau/acme/wiki/ThirdPartyResources[in the wiki].
+https://github.com/hlandau/acmetool/wiki/ThirdPartyResources[in the wiki].
 
-* *https://github.com/hlandau/acme/wiki/ThirdPartyResources[List of
+* *https://github.com/hlandau/acmetool/wiki/ThirdPartyResources[List of
 third party resources]*

--- a/cli/doc.go
+++ b/cli/doc.go
@@ -50,7 +50,7 @@ const manPageTemplate = `{{define "FormatFlags"}}\
 .SH "AUTHOR"
 © 2015 {{.App.Author}} <hlandau@devever.net>  MIT License
 .SH "SEE ALSO"
-Documentation: <https://github.com/hlandau/acme>
+Documentation: <https://github.com/hlandau/acmetool>
 
 Report bugs at: <https://github.com/hlandau/acmetool/issues>
 `


### PR DESCRIPTION
Fix broken URLs and paths in documentation and some scripts. 

Mostly for  `https://github.com/hlandau/acme/` to `https://github.com/hlandau/acmetool/` (some redirects were working, but some were not), but also for other paths (like some referenced files were moved from `_doc` to `_doc/contrib` , `acmeapi` moved to separate repository etc.)