### PR TITLE
Make reconcile Linear - should solve partially #282

### DIFF
--- a/storageops/reconcile-util.go
+++ b/storageops/reconcile-util.go
@@ -98,6 +98,32 @@ func DoesCertificateSatisfy(c *storage.Certificate, t *storage.Target) bool {
 	return true
 }
 
+func FindBestCertificateSatisfyingFromCache(certArray []*storage.Certificate, t *storage.Target) (*storage.Certificate, error) {
+	var bestCert *storage.Certificate
+
+	for _, c := range certArray {
+		if DoesCertificateSatisfy(c, t) {
+			isBetterThan, err := CertificateBetterThan(c, bestCert)
+			if err != nil {
+				continue
+			}
+
+			if isBetterThan {
+				log.Tracef("findBestCertificateSatisfying: %v > %v", c, bestCert)
+				bestCert = c
+			} else {
+				log.Tracef("findBestCertificateSatisfying: %v <= %v", c, bestCert)
+			}
+		}
+	}
+
+	if bestCert == nil {
+		return nil, fmt.Errorf("%v: no certificate satisfies this target", t)
+	}
+
+	return bestCert, nil
+}
+
 func FindBestCertificateSatisfying(s storage.Store, t *storage.Target) (*storage.Certificate, error) {
 	var bestCert *storage.Certificate
 


### PR DESCRIPTION
Basically,

loops a first time over certificates to create a map name => certs[], this allows for lookup of the possible certificates, which allows way faster matching.